### PR TITLE
Reuse the variable that has been declared

### DIFF
--- a/src/main/scala/riscv/core/InstructionDecode.scala
+++ b/src/main/scala/riscv/core/InstructionDecode.scala
@@ -211,5 +211,5 @@ class InstructionDecode extends Module {
   io.reg_write_enable := (opcode === InstructionTypes.RM) || (opcode === InstructionTypes.I) ||
     (opcode === InstructionTypes.L) || (opcode === Instructions.auipc) || (opcode === Instructions.lui) ||
     (opcode === Instructions.jal) || (opcode === Instructions.jalr)
-  io.reg_write_address := io.instruction(11, 7)
+  io.reg_write_address := rd
 }


### PR DESCRIPTION
`rd` already declared. We don't need to fetch it from `instruction` again