### PR TITLE
Resolve the warning when running the project

### DIFF
--- a/src/main/scala/riscv/core/ALUControl.scala
+++ b/src/main/scala/riscv/core/ALUControl.scala
@@ -19,9 +19,7 @@ class ALUControl extends Module {
 
   switch(io.opcode) {
     is(InstructionTypes.I) {
-      io.alu_funct := MuxLookup(
-        io.funct3,
-        ALUFunctions.zero,
+      io.alu_funct := MuxLookup(io.funct3, ALUFunctions.zero)(
         IndexedSeq(
           InstructionsTypeI.addi  -> ALUFunctions.add,
           InstructionsTypeI.slli  -> ALUFunctions.sll,
@@ -35,9 +33,7 @@ class ALUControl extends Module {
       )
     }
     is(InstructionTypes.RM) {
-      io.alu_funct := MuxLookup(
-        io.funct3,
-        ALUFunctions.zero,
+      io.alu_funct := MuxLookup(io.funct3, ALUFunctions.zero)(
         IndexedSeq(
           InstructionsTypeR.add_sub -> Mux(io.funct7(5), ALUFunctions.sub, ALUFunctions.add),
           InstructionsTypeR.sll     -> ALUFunctions.sll,

--- a/src/main/scala/riscv/core/Execute.scala
+++ b/src/main/scala/riscv/core/Execute.scala
@@ -43,9 +43,7 @@ class Execute extends Module {
   io.mem_alu_result := alu.io.result
   io.if_jump_flag := opcode === Instructions.jal ||
     (opcode === Instructions.jalr) ||
-    (opcode === InstructionTypes.B) && MuxLookup(
-      funct3,
-      false.B,
+    (opcode === InstructionTypes.B) && MuxLookup(funct3, false.B)(
       IndexedSeq(
         InstructionsTypeB.beq  -> (io.reg1_data === io.reg2_data),
         InstructionsTypeB.bne  -> (io.reg1_data =/= io.reg2_data),

--- a/src/main/scala/riscv/core/InstructionDecode.scala
+++ b/src/main/scala/riscv/core/InstructionDecode.scala
@@ -147,9 +147,7 @@ class InstructionDecode extends Module {
 
   io.regs_reg1_read_address := Mux(opcode === Instructions.lui, 0.U(Parameters.PhysicalRegisterAddrWidth), rs1)
   io.regs_reg2_read_address := rs2
-  val immediate = MuxLookup(
-    opcode,
-    Cat(Fill(20, io.instruction(31)), io.instruction(31, 20)),
+  val immediate = MuxLookup(opcode, Cat(Fill(20, io.instruction(31)), io.instruction(31, 20)))(
     IndexedSeq(
       InstructionTypes.I -> Cat(Fill(21, io.instruction(31)), io.instruction(30, 20)),
       InstructionTypes.L -> Cat(Fill(21, io.instruction(31)), io.instruction(30, 20)),

--- a/src/main/scala/riscv/core/MemoryAccess.scala
+++ b/src/main/scala/riscv/core/MemoryAccess.scala
@@ -30,22 +30,16 @@ class MemoryAccess extends Module {
 
   when(io.memory_read_enable) {
     val data = io.memory_bundle.read_data
-    io.wb_memory_read_data := MuxLookup(
-      io.funct3,
-      0.U,
+    io.wb_memory_read_data := MuxLookup(io.funct3, 0.U)(
       IndexedSeq(
-        InstructionsTypeL.lb -> MuxLookup(
-          mem_address_index,
-          Cat(Fill(24, data(31)), data(31, 24)),
+        InstructionsTypeL.lb -> MuxLookup(mem_address_index, Cat(Fill(24, data(31)), data(31, 24)))(
           IndexedSeq(
             0.U -> Cat(Fill(24, data(7)), data(7, 0)),
             1.U -> Cat(Fill(24, data(15)), data(15, 8)),
             2.U -> Cat(Fill(24, data(23)), data(23, 16))
           )
         ),
-        InstructionsTypeL.lbu -> MuxLookup(
-          mem_address_index,
-          Cat(Fill(24, 0.U), data(31, 24)),
+        InstructionsTypeL.lbu -> MuxLookup(mem_address_index, Cat(Fill(24, 0.U), data(31, 24)))(
           IndexedSeq(
             0.U -> Cat(Fill(24, 0.U), data(7, 0)),
             1.U -> Cat(Fill(24, 0.U), data(15, 8)),

--- a/src/main/scala/riscv/core/WriteBack.scala
+++ b/src/main/scala/riscv/core/WriteBack.scala
@@ -15,9 +15,7 @@ class WriteBack extends Module {
     val regs_write_source   = Input(UInt(2.W))
     val regs_write_data     = Output(UInt(Parameters.DataWidth))
   })
-  io.regs_write_data := MuxLookup(
-    io.regs_write_source,
-    io.alu_result,
+  io.regs_write_data := MuxLookup(io.regs_write_source, io.alu_result)(
     IndexedSeq(
       RegWriteSource.Memory                 -> io.memory_read_data,
       RegWriteSource.NextInstructionAddress -> (io.instruction_address + 4.U)


### PR DESCRIPTION
When running `sbt test`. I get the warning.

```
[warn] .../ca2023-lab3/src/main/scala/riscv/core/WriteBack.scala:24:25: method apply in object MuxLookup is deprecated (since Chisel 3.6): Use MuxLookup(key, default)(mapping) instead
[warn]   io.regs_write_data := MuxLookup(
[warn]                         ^
[warn] one warning found
```

In [Chisel 3.5](https://oss.sonatype.org/service/local/repositories/releases/archive/edu/berkeley/cs/chisel3_2.13/3.5.6/chisel3_2.13-3.5.6-javadoc.jar/!/chisel3/util/MuxLookup$.html), the syntax of `MuxLookup` is

```scala
MuxLookup(idx, default,
    Array(0.U -> a, 1.U -> b))
```

In [Chisel 3.6](https://oss.sonatype.org/service/local/repositories/releases/archive/edu/berkeley/cs/chisel3_2.13/3.6.0/chisel3_2.13-3.6.0-javadoc.jar/!/chisel3/util/MuxLookup$.html), the syntax of `MuxLookup` is

```scala
MuxLookup(idx, default)(Seq(0.U -> a, 1.U -> b))
```

Since project is build on [Chisel 3.6](https://github.com/sysprog21/ca2023-lab3/blob/main/build.sbt#L7), we have these warnings.
This patch would not affect any code behavior. It just resolves the warning when running `sbt`.